### PR TITLE
RUMM-1212: Let user add additionalConfig at the SDK initialization step

### DIFF
--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeSdk.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeSdk.kt
@@ -32,6 +32,7 @@ internal class BridgeSdk(
         datadog.initialize(appContext, credentials, nativeConfiguration, TrackingConsent.GRANTED)
 
         datadog.registerRumMonitor(RumMonitor.Builder().build())
+        datadog.addRumGlobalAttributes(configuration.additionalConfig ?: emptyMap())
     }
 
     override fun setUser(user: Map<String, Any?>) {

--- a/dd-bridge-android/src/test/kotlin/com/datadog/tools/unit/forge/DdSdkConfigurationForgeryFactory.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/tools/unit/forge/DdSdkConfigurationForgeryFactory.kt
@@ -13,7 +13,9 @@ class DdSdkConfigurationForgeryFactory : ForgeryFactory<DdSdkConfiguration> {
             applicationId = forge.aNullable { getForgery<UUID>().toString() },
             nativeCrashReportEnabled = forge.aNullable { aBool() },
             sampleRate = forge.aNullable { aDouble(0.0, 100.0) },
-            additionalConfig = null // TODO
+            additionalConfig = forge.aMap {
+                forge.anAsciiString() to forge.aString()
+            }
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

This change reads `additionalConfig` field which user may provide during SDK initialization step and adds its content as global RUM attributes for the setup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

