### PR TITLE
RUMM-1235: Use additionalConfig in the bridge

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -37,7 +37,7 @@ object Dependencies {
         const val Unmock = "0.7.5"
 
         // Datadog
-        const val DatadogSdkVersion = "1.9.0-alpha1"
+        const val DatadogSdkVersion = "1.9.0-alpha2"
     }
 
     object Libraries {

--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeSdk.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeSdk.kt
@@ -57,6 +57,11 @@ internal class BridgeSdk(
             crashReportsEnabled = configuration.nativeCrashReportEnabled ?: false,
             rumEnabled = true
         )
+            .setAdditionalConfiguration(
+                configuration.additionalConfig
+                    ?.filterValues { it != null }
+                    ?.mapValues { it.value!! } ?: emptyMap()
+            )
         if (configuration.sampleRate != null) {
             configBuilder.sampleRumSessions(configuration.sampleRate.toFloat())
         }
@@ -67,8 +72,7 @@ internal class BridgeSdk(
         } else if (configuration.site.equals("GOV", ignoreCase = true)) {
             configBuilder.useGovEndpoints()
         }
-        return configBuilder
-            .build()
+        return configBuilder.build()
     }
 
     private fun buildCredentials(configuration: DdSdkConfiguration): Credentials {

--- a/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeSdkTest.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeSdkTest.kt
@@ -235,7 +235,7 @@ internal class BridgeSdkTest {
         val bridgeConfiguration = configuration.copy(
             additionalConfig = null,
             nativeCrashReportEnabled = false,
-            site  = null
+            site = null
         )
         val credentialCaptor = argumentCaptor<Credentials>()
         val configCaptor = argumentCaptor<Configuration>()

--- a/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeSdkTest.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeSdkTest.kt
@@ -106,6 +106,10 @@ internal class BridgeSdkTest {
                 it.hasFieldEqualTo("plugins", emptyList<DatadogPlugin>())
                 it.hasFieldEqualTo("samplingRate", expectedRumSampleRate)
             }
+            .hasFieldEqualTo(
+                "additionalConfig",
+                configuration.additionalConfig?.filterValues { it != null }
+            )
         val credentials = credentialCaptor.firstValue
         assertThat(credentials.clientToken).isEqualTo(configuration.clientToken)
         assertThat(credentials.envName).isEqualTo(configuration.env)
@@ -157,6 +161,10 @@ internal class BridgeSdkTest {
                 it.hasFieldEqualTo("plugins", emptyList<DatadogPlugin>())
                 it.hasFieldEqualTo("samplingRate", expectedRumSampleRate)
             }
+            .hasFieldEqualTo(
+                "additionalConfig",
+                configuration.additionalConfig?.filterValues { it != null }
+            )
         val credentials = credentialCaptor.firstValue
         assertThat(credentials.clientToken).isEqualTo(configuration.clientToken)
         assertThat(credentials.envName).isEqualTo(configuration.env)
@@ -208,6 +216,66 @@ internal class BridgeSdkTest {
                 it.hasFieldEqualTo("plugins", emptyList<DatadogPlugin>())
                 it.hasFieldEqualTo("samplingRate", expectedRumSampleRate)
             }
+            .hasFieldEqualTo(
+                "additionalConfig",
+                configuration.additionalConfig?.filterValues { it != null }
+            )
+        val credentials = credentialCaptor.firstValue
+        assertThat(credentials.clientToken).isEqualTo(configuration.clientToken)
+        assertThat(credentials.envName).isEqualTo(configuration.env)
+        assertThat(credentials.rumApplicationId).isEqualTo(configuration.applicationId)
+        assertThat(credentials.variant).isEqualTo("")
+    }
+
+    @Test
+    fun `𝕄 initialize native SDK 𝕎 initialize() {additionalConfig is null}`(
+        @Forgery configuration: DdSdkConfiguration
+    ) {
+        // Given
+        val bridgeConfiguration = configuration.copy(
+            additionalConfig = null,
+            nativeCrashReportEnabled = false,
+            site  = null
+        )
+        val credentialCaptor = argumentCaptor<Credentials>()
+        val configCaptor = argumentCaptor<Configuration>()
+        val expectedRumSampleRate = bridgeConfiguration.sampleRate?.toFloat() ?: 100f
+
+        // When
+        testedBridgeSdk.initialize(bridgeConfiguration)
+
+        // Then
+        inOrder(mockDatadog) {
+            verify(mockDatadog).initialize(
+                same(mockContext),
+                credentialCaptor.capture(),
+                configCaptor.capture(),
+                eq(TrackingConsent.GRANTED)
+            )
+            verify(mockDatadog).registerRumMonitor(any())
+        }
+        assertThat(configCaptor.firstValue)
+            .hasField("coreConfig") {
+                it.hasFieldEqualTo("needsClearTextHttp", false)
+                it.hasFieldEqualTo("firstPartyHosts", emptyList<String>())
+                it.hasFieldEqualTo("batchSize", BatchSize.MEDIUM)
+                it.hasFieldEqualTo("uploadFrequency", UploadFrequency.AVERAGE)
+            }
+            .hasField("logsConfig") {
+                it.hasFieldEqualTo("endpointUrl", DatadogEndpoint.LOGS_US)
+                it.hasFieldEqualTo("plugins", emptyList<DatadogPlugin>())
+            }
+            .hasField("tracesConfig") {
+                it.hasFieldEqualTo("endpointUrl", DatadogEndpoint.TRACES_US)
+                it.hasFieldEqualTo("plugins", emptyList<DatadogPlugin>())
+            }
+            .hasFieldEqualTo("crashReportConfig", null)
+            .hasField("rumConfig") {
+                it.hasFieldEqualTo("endpointUrl", DatadogEndpoint.RUM_US)
+                it.hasFieldEqualTo("plugins", emptyList<DatadogPlugin>())
+                it.hasFieldEqualTo("samplingRate", expectedRumSampleRate)
+            }
+            .hasFieldEqualTo("additionalConfig", emptyMap<String, Any>())
         val credentials = credentialCaptor.firstValue
         assertThat(credentials.clientToken).isEqualTo(configuration.clientToken)
         assertThat(credentials.envName).isEqualTo(configuration.env)

--- a/dd-bridge-android/src/test/kotlin/com/datadog/tools/unit/forge/DdSdkConfigurationForgeryFactory.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/tools/unit/forge/DdSdkConfigurationForgeryFactory.kt
@@ -14,7 +14,13 @@ class DdSdkConfigurationForgeryFactory : ForgeryFactory<DdSdkConfiguration> {
             nativeCrashReportEnabled = forge.aNullable { aBool() },
             sampleRate = forge.aNullable { aDouble(0.0, 100.0) },
             site = forge.aNullable { anElementFrom("US", "EU", "GOV") },
-            additionalConfig = null // TODO
+            additionalConfig = forge.aMap {
+                forge.anAsciiString() to forge.anElementFrom(
+                    forge.aMap { forge.anAsciiString() to forge.aString() },
+                    forge.aString(),
+                    null
+                )
+            }
         )
     }
 }

--- a/dd-bridge-android/transitiveDependencies
+++ b/dd-bridge-android/transitiveDependencies
@@ -1,6 +1,6 @@
 Dependencies List
 
-com.datadoghq:dd-sdk-android:1.9.0-alpha1                       : 1061 Kb
+com.datadoghq:dd-sdk-android:1.9.0-alpha2                       : 1061 Kb
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb


### PR DESCRIPTION
### What does this PR do?

This change links `additionalConfig` coming from `dd-sdk-reactnative` to `additionalConfig` consumed by `dd-sdk-android`.

### Additional Notes

Build will fail for now, because there is no label of `dd-sdk-android` published yet, which supports `additionalConfig`.

Related PRs: https://github.com/DataDog/dd-sdk-reactnative/pull/32 and https://github.com/DataDog/dd-sdk-android/pull/549

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

