### PR TITLE
Update SDK dependency to 1.9.0 stable, bump version to 0.4.1

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -37,7 +37,7 @@ object Dependencies {
         const val Unmock = "0.7.5"
 
         // Datadog
-        const val DatadogSdkVersion = "1.9.0-alpha2"
+        const val DatadogSdkVersion = "1.9.0"
     }
 
     object Libraries {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -14,5 +14,5 @@ object AndroidConfig {
     const val MIN_SDK = 19
     const val BUILD_TOOLS_VERSION = "30.0.2"
 
-    val VERSION = Version(0, 4, 0)
+    val VERSION = Version(0, 4, 1)
 }

--- a/dd-bridge-android/transitiveDependencies
+++ b/dd-bridge-android/transitiveDependencies
@@ -1,6 +1,6 @@
 Dependencies List
 
-com.datadoghq:dd-sdk-android:1.9.0-alpha2                       : 1061 Kb
+com.datadoghq:dd-sdk-android:1.9.0                              : 1062 Kb
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb


### PR DESCRIPTION
### What does this PR do?

This change updates DD SDK dependency to `1.9.0` stable to be able to proceed with Resource Timings on React Native side.

Also this change bumps the version of the artifact to be able to publish it. `0.4.1` is chosen to be consistent with https://github.com/DataDog/dd-bridge-ios/pull/13.
