### PR TITLE
RUMM-1418: Use isolated tracer, fix its initialization

### DIFF
--- a/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeTraceTest.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeTraceTest.kt
@@ -7,8 +7,6 @@
 package com.datadog.android.bridge.internal
 
 import com.datadog.android.bridge.DdTrace
-import com.datadog.tools.unit.setFieldValue
-import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.never
@@ -24,10 +22,7 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.opentracing.Span
 import io.opentracing.SpanContext
 import io.opentracing.Tracer
-import io.opentracing.noop.NoopTracerFactory
-import io.opentracing.util.GlobalTracer
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -86,15 +81,7 @@ internal class BridgeTraceTest {
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
 
-        GlobalTracer.registerIfAbsent(mockTracer)
-
-        testedTrace = BridgeTrace()
-    }
-
-    @AfterEach
-    fun `tear down`() {
-        GlobalTracer.get().setFieldValue("isRegistered", false)
-        GlobalTracer::class.java.setStaticValue("tracer", NoopTracerFactory.create())
+        testedTrace = BridgeTrace(tracerProvider = { mockTracer })
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This change switches to the isolated tracer usage (tracer unique to the RN, instead of using the global one), plus it fixes its initialization (it cannot be created reliably before SDK initialization is completed, per https://github.com/DataDog/dd-sdk-android/blob/95af21983a5237495e42e5015bfc687509575267/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt#L77, because `TracesFeature.persistenceStrategy.getWriter()` will be no-op in this case).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

