### PR TITLE
RUMM-1564 read service name from additionalConfig

### DIFF
--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeSdk.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeSdk.kt
@@ -59,7 +59,7 @@ internal class BridgeSdk(
     // region Internal
 
     private fun configureSdkVerbosity(configuration: DdSdkConfiguration) {
-        val verbosityConfig = configuration.additionalConfig?.get(SDK_VERBOSITY) as? String
+        val verbosityConfig = configuration.additionalConfig?.get(DD_SDK_VERBOSITY) as? String
         val verbosity = when (verbosityConfig?.toLowerCase(Locale.US)) {
             "debug" -> Log.DEBUG
             "info" -> Log.INFO
@@ -96,7 +96,7 @@ internal class BridgeSdk(
             configBuilder.useGovEndpoints()
         }
 
-        val viewTracking = configuration.additionalConfig?.get(NATIVE_VIEW_TRACKING) as? Boolean
+        val viewTracking = configuration.additionalConfig?.get(DD_NATIVE_VIEW_TRACKING) as? Boolean
         if (viewTracking == true) {
             // Use sensible default
             configBuilder.useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
@@ -107,11 +107,13 @@ internal class BridgeSdk(
     }
 
     private fun buildCredentials(configuration: DdSdkConfiguration): Credentials {
+        val serviceName = configuration.additionalConfig?.get(DD_SERVICE_NAME) as? String
         return Credentials(
             clientToken = configuration.clientToken,
             envName = configuration.env,
             rumApplicationId = configuration.applicationId,
-            variant = ""
+            variant = "",
+            serviceName = serviceName
         )
     }
 
@@ -134,7 +136,8 @@ internal class BridgeSdk(
     // endregion
 
     companion object {
-        internal const val NATIVE_VIEW_TRACKING = "_dd.native_view_tracking"
-        internal const val SDK_VERBOSITY = "_dd.sdk_verbosity"
+        internal const val DD_NATIVE_VIEW_TRACKING = "_dd.native_view_tracking"
+        internal const val DD_SDK_VERBOSITY = "_dd.sdk_verbosity"
+        internal const val DD_SERVICE_NAME = "_dd.service_name"
     }
 }

--- a/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeSdkTest.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeSdkTest.kt
@@ -437,6 +437,7 @@ internal class BridgeSdkTest {
         assertThat(credentials.envName).isEqualTo(configuration.env)
         assertThat(credentials.rumApplicationId).isEqualTo(configuration.applicationId)
         assertThat(credentials.variant).isEqualTo("")
+        assertThat(credentials.serviceName).isNull()
     }
 
     @Test
@@ -474,7 +475,7 @@ internal class BridgeSdkTest {
         // Given
         val bridgeConfiguration = configuration.copy(
             additionalConfig = mapOf(
-                BridgeSdk.NATIVE_VIEW_TRACKING to false
+                BridgeSdk.DD_NATIVE_VIEW_TRACKING to false
             )
         )
         val credentialCaptor = argumentCaptor<Credentials>()
@@ -506,7 +507,7 @@ internal class BridgeSdkTest {
         // Given
         val bridgeConfiguration = configuration.copy(
             additionalConfig = mapOf(
-                BridgeSdk.NATIVE_VIEW_TRACKING to true
+                BridgeSdk.DD_NATIVE_VIEW_TRACKING to true
             )
         )
         val credentialCaptor = argumentCaptor<Credentials>()
@@ -546,7 +547,7 @@ internal class BridgeSdkTest {
         }
         val bridgeConfiguration = configuration.copy(
             additionalConfig = mapOf(
-                BridgeSdk.SDK_VERBOSITY to verbosityName
+                BridgeSdk.DD_SDK_VERBOSITY to verbosityName
             )
         )
 
@@ -565,7 +566,7 @@ internal class BridgeSdkTest {
         // Given
         val bridgeConfiguration = configuration.copy(
             additionalConfig = mapOf(
-                BridgeSdk.SDK_VERBOSITY to verbosity
+                BridgeSdk.DD_SDK_VERBOSITY to verbosity
             )
         )
 
@@ -574,6 +575,33 @@ internal class BridgeSdkTest {
 
         // Then
         verify(mockDatadog, never()).setVerbosity(any())
+    }
+
+    @Test
+    fun `𝕄 initialize native SDK 𝕎 initialize() {custom service name}`(
+        @Forgery configuration: DdSdkConfiguration,
+        @StringForgery serviceName: String
+    ) {
+        // Given
+        val bridgeConfiguration = configuration.copy(
+            additionalConfig = mapOf(
+                BridgeSdk.DD_SERVICE_NAME to serviceName
+            )
+        )
+        val credentialCaptor = argumentCaptor<Credentials>()
+        val configCaptor = argumentCaptor<Configuration>()
+
+        // When
+        testedBridgeSdk.initialize(bridgeConfiguration)
+
+        // Then
+        verify(mockDatadog).initialize(
+            same(mockContext),
+            credentialCaptor.capture(),
+            configCaptor.capture(),
+            eq(configuration.trackingConsent.asTrackingConsent())
+        )
+        assertThat(credentialCaptor.firstValue.serviceName).isEqualTo(serviceName)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Let customers set a custom `serviceName` tag on their data using the additional configuration `_dd.service_name`