### PR TITLE
Bump SDK dependency to 1.10.0

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -37,7 +37,7 @@ object Dependencies {
         const val Unmock = "0.7.5"
 
         // Datadog
-        const val DatadogSdkVersion = "1.10.0-rc1"
+        const val DatadogSdkVersion = "1.10.0"
     }
 
     object Libraries {


### PR DESCRIPTION
`1.10.0` contains important fix which is necessary for React Native bugfix: support proper nested maps serialization.