### PR TITLE
RUMM-1623: Remove Bintray and JCenter repo references

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,7 +134,7 @@ test:release:
     - GRADLE_OPTS="-XX:MaxPermSize=512m -Xmx2560m" ./gradlew :unitTestRelease --stacktrace --no-daemon
     - bash <(cat ./codecov.sh) -t $CODECOV_TOKEN
 
-# PUBLISH ARTIFACTS ON BINTRAY
+# PUBLISH ARTIFACTS ON SONATYPE
 
 publish:release:
   tags: [ "runner:main" ]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ buildscript {
         google()
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Gradle) }
-        jcenter()
     }
 
     dependencies {
@@ -22,7 +21,6 @@ buildscript {
         classpath(com.datadog.gradle.Dependencies.ClassPaths.Kotlin)
         classpath(com.datadog.gradle.Dependencies.ClassPaths.KtLint)
         classpath(com.datadog.gradle.Dependencies.ClassPaths.Dokka)
-        classpath(com.datadog.gradle.Dependencies.ClassPaths.Bintray)
         classpath(com.datadog.gradle.Dependencies.ClassPaths.Unmock)
     }
 }
@@ -33,7 +31,6 @@ allprojects {
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Jitpack) }
         flatDir { dirs("libs") }
-        jcenter()
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,8 +37,7 @@ dependencies {
     implementation("com.android.tools.build:gradle:4.1.2")
     implementation("com.github.ben-manes:gradle-versions-plugin:0.27.0")
     implementation("me.xdrop:fuzzywuzzy:1.2.0")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.10")
-    implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.32")
     implementation("org.apache.maven:maven-model:3.6.3")
     implementation("io.github.gradle-nexus:publish-plugin:1.1.0")
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -30,10 +30,9 @@ object Dependencies {
         const val MockitoKotlin = "2.2.0"
 
         // Tools
-        const val Detekt = "1.6.0"
+        const val Detekt = "1.17.0"
         const val KtLint = "9.4.0"
-        const val Dokka = "1.4.10"
-        const val Bintray = "1.8.4"
+        const val Dokka = "1.4.32"
         const val Unmock = "0.7.5"
 
         // Datadog
@@ -82,13 +81,11 @@ object Dependencies {
         const val Kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin}"
         const val KtLint = "org.jlleitschuh.gradle:ktlint-gradle:${Versions.KtLint}"
         const val Dokka = "org.jetbrains.dokka:dokka-gradle-plugin:${Versions.Dokka}"
-        const val Bintray = "com.jfrog.bintray.gradle:gradle-bintray-plugin:${Versions.Bintray}"
         const val Unmock = "de.mobilej.unmock:UnMockPlugin:${Versions.Unmock}"
     }
 
     object Repositories {
         const val Gradle = "https://plugins.gradle.org/m2/"
         const val Jitpack = "https://jitpack.io"
-        const val Datadog = "https://dl.bintray.com/datadog/datadog-maven"
     }
 }


### PR DESCRIPTION
### What does this PR do?

This change is similar to https://github.com/DataDog/dd-sdk-android/pull/704, removes Bintray/JCenter repo references and updates libs which were hosted there before.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

