### PR TITLE
Fix long task duration extraction

### DIFF
--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeSdk.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeSdk.kt
@@ -105,7 +105,8 @@ internal class BridgeSdk(
             configBuilder.useViewTrackingStrategy(NoOpViewTrackingStrategy)
         }
 
-        val longTask = configuration.additionalConfig?.get(DD_LONG_TASK_THRESHOLD) as? Long
+        val longTask =
+            (configuration.additionalConfig?.get(DD_LONG_TASK_THRESHOLD) as? Number)?.toLong()
         if (longTask != null) {
             configBuilder.trackLongTasks(longTask)
         }

--- a/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeSdkTest.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeSdkTest.kt
@@ -27,7 +27,6 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
-import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.MapForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
@@ -1165,8 +1164,14 @@ internal class BridgeSdkTest {
     @Test
     fun `𝕄 set long task threshold 𝕎 initialize() {custom long task threshold}`(
         @Forgery configuration: DdSdkConfiguration,
-        @LongForgery(0, 65536) threshold: Long
+        forge: Forge
     ) {
+        // floating-point type (coming from JS) and integer type (other frameworks)
+        val threshold = forge.anElementFrom(
+            forge.aLong(min = 0, max = 65536),
+            forge.aDouble(min = 0.0, max = 65536.0)
+        )
+
         // Given
         val bridgeConfiguration = configuration.copy(
             additionalConfig = mapOf(
@@ -1194,7 +1199,7 @@ internal class BridgeSdkTest {
                             "com.datadog.android.rum.internal.instrumentation." +
                                 "MainLooperLongTaskStrategy"
                         )
-                        .hasFieldEqualTo("thresholdMs", threshold)
+                        .hasFieldEqualTo("thresholdMs", threshold.toLong())
                 }
             }
     }


### PR DESCRIPTION
### What does this PR do?

This change fixed extraction of the long task duration value: in JS all the numbers are floating-point numbers, so when any number (even written without floating part) comes to JVM layer, it has `Double` type and cast to `Long` always fails.

This change fixes this issue by casting to the common parent of all numbers type - `Number` (so that code could work for other frameworks, which can pass `Int` or `Long`) and then getting `Long` value.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

