### PR TITLE
Update to version 0.5: Swap context and timestamp argument, add support of the resource size argument in the stopResource call (RUMM-1700)

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -14,5 +14,5 @@ object AndroidConfig {
     const val MIN_SDK = 19
     const val BUILD_TOOLS_VERSION = "30.0.2"
 
-    val VERSION = Version(0, 4, 6)
+    val VERSION = Version(0, 5, 0)
 }

--- a/dd-bridge-android/apiSurface
+++ b/dd-bridge-android/apiSurface
@@ -9,14 +9,14 @@ interface com.datadog.android.bridge.DdLogs
   fun warn(String, Map<String, Any?>): Unit
   fun error(String, Map<String, Any?>): Unit
 interface com.datadog.android.bridge.DdRum
-  fun startView(String, String, Long, Map<String, Any?>): Unit
-  fun stopView(String, Long, Map<String, Any?>): Unit
-  fun startAction(String, String, Long, Map<String, Any?>): Unit
-  fun stopAction(Long, Map<String, Any?>): Unit
-  fun addAction(String, String, Long, Map<String, Any?>): Unit
-  fun startResource(String, String, String, Long, Map<String, Any?>): Unit
-  fun stopResource(String, Long, String, Long, Map<String, Any?>): Unit
-  fun addError(String, String, String, Long, Map<String, Any?>): Unit
+  fun startView(String, String, Map<String, Any?>, Long): Unit
+  fun stopView(String, Map<String, Any?>, Long): Unit
+  fun startAction(String, String, Map<String, Any?>, Long): Unit
+  fun stopAction(Map<String, Any?>, Long): Unit
+  fun addAction(String, String, Map<String, Any?>, Long): Unit
+  fun startResource(String, String, String, Map<String, Any?>, Long): Unit
+  fun stopResource(String, Long, String, Long, Map<String, Any?>, Long): Unit
+  fun addError(String, String, String, Map<String, Any?>, Long): Unit
   fun addTiming(String): Unit
 interface com.datadog.android.bridge.DdSdk
   fun initialize(DdSdkConfiguration): Unit
@@ -26,8 +26,8 @@ interface com.datadog.android.bridge.DdSdk
 class com.datadog.android.bridge.DdSdkConfiguration
   constructor(String, String, String? = null, Boolean? = null, Double? = null, String? = null, String? = null, Map<String, Any?>? = null)
 interface com.datadog.android.bridge.DdTrace
-  fun startSpan(String, Long, Map<String, Any?>): String
-  fun finishSpan(String, Long, Map<String, Any?>): Unit
+  fun startSpan(String, Map<String, Any?>, Long): String
+  fun finishSpan(String, Map<String, Any?>, Long): Unit
 object com.datadog.android.bridge.internal.NoOpViewTrackingStrategy : com.datadog.android.rum.tracking.ViewTrackingStrategy
   override fun register(android.content.Context)
   override fun unregister(android.content.Context?)

--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/DdRum.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/DdRum.kt
@@ -14,27 +14,27 @@ interface DdRum {
     /**
      * Start tracking a RUM View.
      */
-    fun startView(key: String, name: String, timestampMs: Long, context: Map<String, Any?>): Unit
+    fun startView(key: String, name: String, context: Map<String, Any?>, timestampMs: Long): Unit
 
     /**
      * Stop tracking a RUM View.
      */
-    fun stopView(key: String, timestampMs: Long, context: Map<String, Any?>): Unit
+    fun stopView(key: String, context: Map<String, Any?>, timestampMs: Long): Unit
 
     /**
      * Start tracking a RUM Action.
      */
-    fun startAction(type: String, name: String, timestampMs: Long, context: Map<String, Any?>): Unit
+    fun startAction(type: String, name: String, context: Map<String, Any?>, timestampMs: Long): Unit
 
     /**
      * Stop tracking the ongoing RUM Action.
      */
-    fun stopAction(timestampMs: Long, context: Map<String, Any?>): Unit
+    fun stopAction(context: Map<String, Any?>, timestampMs: Long): Unit
 
     /**
      * Add a RUM Action.
      */
-    fun addAction(type: String, name: String, timestampMs: Long, context: Map<String, Any?>): Unit
+    fun addAction(type: String, name: String, context: Map<String, Any?>, timestampMs: Long): Unit
 
     /**
      * Start tracking a RUM Resource.
@@ -43,8 +43,8 @@ interface DdRum {
         key: String,
         method: String,
         url: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ): Unit
 
     /**
@@ -54,8 +54,9 @@ interface DdRum {
         key: String,
         statusCode: Long,
         kind: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        size: Long,
+        context: Map<String, Any?>,
+        timestampMs: Long
     ): Unit
 
     /**
@@ -65,8 +66,8 @@ interface DdRum {
         message: String,
         source: String,
         stacktrace: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ): Unit
 
     /**

--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/DdRum.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/DdRum.kt
@@ -50,6 +50,7 @@ interface DdRum {
     /**
      * Stop tracking a RUM Resource.
      */
+    @Suppress("LongParameterList")
     fun stopResource(
         key: String,
         statusCode: Long,

--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/DdTrace.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/DdTrace.kt
@@ -14,10 +14,10 @@ interface DdTrace {
     /**
      * Start a span, and returns a unique identifier for the span.
      */
-    fun startSpan(operation: String, timestampMs: Long, context: Map<String, Any?>): String
+    fun startSpan(operation: String, context: Map<String, Any?>, timestampMs: Long): String
 
     /**
      * Finish a started span.
      */
-    fun finishSpan(spanId: String, timestampMs: Long, context: Map<String, Any?>): Unit
+    fun finishSpan(spanId: String, context: Map<String, Any?>, timestampMs: Long): Unit
 }

--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeRum.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeRum.kt
@@ -19,8 +19,8 @@ internal class BridgeRum : DdRum {
     override fun startView(
         key: String,
         name: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ) {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)
@@ -32,7 +32,7 @@ internal class BridgeRum : DdRum {
         )
     }
 
-    override fun stopView(key: String, timestampMs: Long, context: Map<String, Any?>) {
+    override fun stopView(key: String, context: Map<String, Any?>, timestampMs: Long) {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)
         }
@@ -45,8 +45,8 @@ internal class BridgeRum : DdRum {
     override fun startAction(
         type: String,
         name: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ) {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)
@@ -58,7 +58,7 @@ internal class BridgeRum : DdRum {
         )
     }
 
-    override fun stopAction(timestampMs: Long, context: Map<String, Any?>) {
+    override fun stopAction(context: Map<String, Any?>, timestampMs: Long) {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)
         }
@@ -70,8 +70,8 @@ internal class BridgeRum : DdRum {
     override fun addAction(
         type: String,
         name: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ) {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)
@@ -87,8 +87,8 @@ internal class BridgeRum : DdRum {
         key: String,
         method: String,
         url: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ) {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)
@@ -105,8 +105,9 @@ internal class BridgeRum : DdRum {
         key: String,
         statusCode: Long,
         kind: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        size: Long,
+        context: Map<String, Any?>,
+        timestampMs: Long
     ) {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)
@@ -124,8 +125,8 @@ internal class BridgeRum : DdRum {
         message: String,
         source: String,
         stacktrace: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ) {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)

--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeRum.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeRum.kt
@@ -112,11 +112,16 @@ internal class BridgeRum : DdRum {
         val attributes = context.toMutableMap().apply {
             put(RumAttributes.INTERNAL_TIMESTAMP, timestampMs)
         }
+        val resourceSize = if (size == MISSING_RESOURCE_SIZE) {
+            null
+        } else {
+            size
+        }
         GlobalRum.get().stopResource(
             key = key,
             statusCode = statusCode.toInt(),
             kind = kind.asRumResourceKind(),
-            size = null,
+            size = resourceSize,
             attributes = attributes
         )
     }
@@ -185,4 +190,8 @@ internal class BridgeRum : DdRum {
     }
 
     // endregion
+
+    companion object {
+        private const val MISSING_RESOURCE_SIZE = -1L
+    }
 }

--- a/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeTrace.kt
+++ b/dd-bridge-android/src/main/kotlin/com/datadog/android/bridge/internal/BridgeTrace.kt
@@ -24,8 +24,8 @@ internal class BridgeTrace(
 
     override fun startSpan(
         operation: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ): String {
         val span = tracer.buildSpan(operation)
             .withStartTimestamp(TimeUnit.MILLISECONDS.toMicros(timestampMs))
@@ -41,8 +41,8 @@ internal class BridgeTrace(
 
     override fun finishSpan(
         spanId: String,
-        timestampMs: Long,
-        context: Map<String, Any?>
+        context: Map<String, Any?>,
+        timestampMs: Long
     ) {
         val span = spanMap.remove(spanId) ?: return
         span.setTags(context)

--- a/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeRumTest.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeRumTest.kt
@@ -92,7 +92,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.startView(key, name, fakeTimestamp, fakeContext)
+        testedDdRum.startView(key, name, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).startView(key, name, updatedContext)
@@ -106,7 +106,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.stopView(key, fakeTimestamp, fakeContext)
+        testedDdRum.stopView(key, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).stopView(key, updatedContext)
@@ -121,7 +121,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.addAction(type.name, name, fakeTimestamp, fakeContext)
+        testedDdRum.addAction(type.name, name, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).addUserAction(type, name, updatedContext)
@@ -136,7 +136,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.addAction(type, name, fakeTimestamp, fakeContext)
+        testedDdRum.addAction(type, name, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).addUserAction(RumActionType.CUSTOM, name, updatedContext)
@@ -151,7 +151,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.startAction(type.name, name, fakeTimestamp, fakeContext)
+        testedDdRum.startAction(type.name, name, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).startUserAction(type, name, updatedContext)
@@ -166,7 +166,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.startAction(type, name, fakeTimestamp, fakeContext)
+        testedDdRum.startAction(type, name, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).startUserAction(RumActionType.CUSTOM, name, updatedContext)
@@ -178,7 +178,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.stopAction(fakeTimestamp, fakeContext)
+        testedDdRum.stopAction(fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).stopUserAction(updatedContext)
@@ -194,7 +194,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.startResource(key, method, url, fakeTimestamp, fakeContext)
+        testedDdRum.startResource(key, method, url, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).startResource(key, method, url, updatedContext)
@@ -260,7 +260,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.addError(message, source.name, stackTrace, fakeTimestamp, fakeContext)
+        testedDdRum.addError(message, source.name, stackTrace, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).addErrorWithStacktrace(message, source, stackTrace, updatedContext)
@@ -276,7 +276,7 @@ internal class BridgeRumTest {
         val updatedContext = fakeContext + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedDdRum.addError(message, source, stackTrace, fakeTimestamp, fakeContext)
+        testedDdRum.addError(message, source, stackTrace, fakeContext, fakeTimestamp)
 
         // Then
         verify(mockRumMonitor).addErrorWithStacktrace(

--- a/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeTraceTest.kt
+++ b/dd-bridge-android/src/test/kotlin/com/datadog/android/bridge/internal/BridgeTraceTest.kt
@@ -100,7 +100,7 @@ internal class BridgeTraceTest {
     @Test
     fun `M start a span W startSpan() `() {
         // When
-        val id = testedTrace.startSpan(fakeOperation, fakeTimestamp, emptyMap())
+        val id = testedTrace.startSpan(fakeOperation, emptyMap(), fakeTimestamp)
 
         // Then
         assertThat(id).isEqualTo(fakeSpanId)
@@ -118,8 +118,8 @@ internal class BridgeTraceTest {
         val endTimestamp = fakeTimestamp + duration
 
         // When
-        val id = testedTrace.startSpan(fakeOperation, fakeTimestamp, emptyMap())
-        testedTrace.finishSpan(id, endTimestamp, emptyMap())
+        val id = testedTrace.startSpan(fakeOperation, emptyMap(), fakeTimestamp)
+        testedTrace.finishSpan(id, emptyMap(), endTimestamp)
 
         // Then
         assertThat(id).isEqualTo(fakeSpanId)
@@ -136,8 +136,8 @@ internal class BridgeTraceTest {
         val endTimestamp = fakeTimestamp + duration
 
         // When
-        val id = testedTrace.startSpan(fakeOperation, fakeTimestamp, emptyMap())
-        testedTrace.finishSpan(otherSpanId, endTimestamp, emptyMap())
+        val id = testedTrace.startSpan(fakeOperation, emptyMap(), fakeTimestamp)
+        testedTrace.finishSpan(otherSpanId, emptyMap(), endTimestamp)
 
         // Then
         assertThat(id).isEqualTo(fakeSpanId)
@@ -152,8 +152,8 @@ internal class BridgeTraceTest {
         val endTimestamp = fakeTimestamp + duration
 
         // When
-        val id = testedTrace.startSpan(fakeOperation, fakeTimestamp, fakeContext)
-        testedTrace.finishSpan(id, endTimestamp, emptyMap())
+        val id = testedTrace.startSpan(fakeOperation, fakeContext, fakeTimestamp)
+        testedTrace.finishSpan(id, emptyMap(), endTimestamp)
 
         // Then
         assertThat(id).isEqualTo(fakeSpanId)
@@ -173,8 +173,8 @@ internal class BridgeTraceTest {
         val endTimestamp = fakeTimestamp + duration
 
         // When
-        val id = testedTrace.startSpan(fakeOperation, fakeTimestamp, emptyMap())
-        testedTrace.finishSpan(id, endTimestamp, fakeContext)
+        val id = testedTrace.startSpan(fakeOperation, emptyMap(), fakeTimestamp)
+        testedTrace.finishSpan(id, fakeContext, endTimestamp)
 
         // Then
         assertThat(id).isEqualTo(fakeSpanId)
@@ -197,8 +197,8 @@ internal class BridgeTraceTest {
         fakeGlobalState.forEach { (k, v) ->
             GlobalState.addAttribute(k, v)
         }
-        val id = testedTrace.startSpan(fakeOperation, fakeTimestamp, fakeContext)
-        testedTrace.finishSpan(id, endTimestamp, emptyMap())
+        val id = testedTrace.startSpan(fakeOperation, fakeContext, fakeTimestamp)
+        testedTrace.finishSpan(id, emptyMap(), endTimestamp)
 
         // Then
         assertThat(id).isEqualTo(fakeSpanId)
@@ -222,11 +222,11 @@ internal class BridgeTraceTest {
         val expectedAttributes = fakeContext + fakeGlobalState
 
         // When
-        val id = testedTrace.startSpan(fakeOperation, fakeTimestamp, emptyMap())
+        val id = testedTrace.startSpan(fakeOperation, emptyMap(), fakeTimestamp)
         fakeGlobalState.forEach { (k, v) ->
             GlobalState.addAttribute(k, v)
         }
-        testedTrace.finishSpan(id, endTimestamp, fakeContext)
+        testedTrace.finishSpan(id, fakeContext, endTimestamp)
 
         // Then
         assertThat(id).isEqualTo(fakeSpanId)


### PR DESCRIPTION
This change adds the following:

* Does the swap of `context` and `timestamp` arguments to be aligned with their priority in case of the positional usage.
* Adds support of the resource size argument in the `Rum#stopResource` call.
* Bumps version to `0.5.0`