### PR TITLE
Update to version 1.14.0-beta2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ kotlinGrammarParser = "c35b50fa44"
 jsonSchemaValidator = "1.12.1"
 
 # Datadog
-datadogSdk = "1.14.0-beta1"
+datadogSdk = "1.14.0-beta2"
 
 [libraries]
 


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 1.14.0-beta1 to version 1.14.0-beta2: [diff](https://github.com/DataDog/dd-sdk-android/compare/1.14.0-beta1...1.14.0-beta2)